### PR TITLE
readme: add reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 A NixVim Configuration
 
 ## References
-[Elythh](https://github.com/elythh/nixvim)
+ - [Elythh](https://github.com/elythh/nixvim)
+ - [MikaelFangel](https://github.com/MikaelFangel/nixvim-config)


### PR DESCRIPTION
I guess based on your latest activity starring the https://github.com/MikaelFangel/nixvim-config repo and then adding the copilot-chat config with identical keymaps to mine would make it appropriate to add the repo as a reference as well. Hope you agree (: 

### Changes
 - Added reference to nixvim configuration.