### PR TITLE
patch: fix renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,6 @@
   "platform": "github",
   "semanticCommits": true,
   "labels": ["renovate"],
-  "repositories": ["dc-tec/k8s-gitops"],
+  "repositories": ["dc-tec/nixvim"],
   "extends": ["config:recommended"],
 }


### PR DESCRIPTION
The renovate config pointed to the wrong repository, fixed in this PR so it points to the Nixvim repository.