### PR TITLE
patch: mix fixes

### DIFF
--- a/config/plugins/cmp/cmp.nix
+++ b/config/plugins/cmp/cmp.nix
@@ -5,7 +5,7 @@
       enable = true;
       settings = {
         autoEnableSources = true;
-        experimental = {ghost_text = true;};
+        experimental = {ghost_text = false;};
         performance = {
           debounce = 60;
           fetchingTimeout = 200;

--- a/config/plugins/editor/navic.nix
+++ b/config/plugins/editor/navic.nix
@@ -1,38 +1,40 @@
 _: {
   plugins.navic = {
     enable = true;
-    separator = "  ";
-    highlight = true;
-    depthLimit = 5;
-    lsp = {
-      autoAttach = true;
-    };
-    icons = {
-      Array = "󱃵  ";
-      Boolean = "  ";
-      Class = "  ";
-      Constant = "  ";
-      Constructor = "  ";
-      Enum = " ";
-      EnumMember = " ";
-      Event = " ";
-      Field = "󰽏 ";
-      File = " ";
-      Function = "󰡱 ";
-      Interface = " ";
-      Key = "  ";
-      Method = " ";
-      Module = "󰕳 ";
-      Namespace = " ";
-      Null = "󰟢 ";
-      Number = " ";
-      Object = "  ";
-      Operator = " ";
-      Package = "󰏖 ";
-      String = " ";
-      Struct = " ";
-      TypeParameter = " ";
-      Variable = " ";
+    settings = {
+      separator = "  ";
+      highlight = true;
+      depthLimit = 5;
+      lsp = {
+        autoAttach = true;
+      };
+      icons = {
+        Array = "󱃵  ";
+        Boolean = "  ";
+        Class = "  ";
+        Constant = "  ";
+        Constructor = "  ";
+        Enum = " ";
+        EnumMember = " ";
+        Event = " ";
+        Field = "󰽏 ";
+        File = " ";
+        Function = "󰡱 ";
+        Interface = " ";
+        Key = "  ";
+        Method = " ";
+        Module = "󰕳 ";
+        Namespace = " ";
+        Null = "󰟢 ";
+        Number = " ";
+        Object = "  ";
+        Operator = " ";
+        Package = "󰏖 ";
+        String = " ";
+        Struct = " ";
+        TypeParameter = " ";
+        Variable = " ";
+      };
     };
   };
 }

--- a/config/plugins/ui/lualine.nix
+++ b/config/plugins/ui/lualine.nix
@@ -1,98 +1,102 @@
 _: {
   plugins.lualine = {
     enable = true;
-    globalstatus = true;
-    extensions = [
-      "fzf"
-      "neo-tree"
-    ];
-    disabledFiletypes = {
-      statusline = ["startup" "alpha"];
-    };
-    theme = "catppuccin";
-    sections = {
-      lualine_a = [
-        {
-          name = "mode";
-          icon = " ";
-        }
-      ];
-      lualine_b = [
-        {
-          name = "branch";
-          icon = "";
-        }
-        {
-          name = "diff";
-          extraConfig = {
-            symbols = {
-              added = " ";
-              modified = " ";
-              removed = " ";
-            };
-          };
-        }
-      ];
-      lualine_c = [
-        {
-          name = "diagnostics";
-          extraConfig = {
-            sources = ["nvim_lsp"];
-            symbols = {
-              error = " ";
-              warn = " ";
-              info = " ";
-              hint = "󰝶 ";
-            };
-          };
-        }
-        {
-          name = "navic";
-        }
-      ];
-      lualine_x = [
-        {
-          name = "filetype";
-          extraConfig = {
-            icon_only = true;
-            separator = "";
-            padding = {
-              left = 1;
-              right = 0;
-            };
-          };
-        }
-        {
-          name = "filename";
-          extraConfig = {
-            path = 1;
-          };
-        }
-        {
-          name.__raw = ''
-            function()
-              local icon = " "
-              local status = require("copilot.api").status.data
-              return icon .. (status.message or " ")
-            end,
+    settings = {
+      options = {
+        globalstatus = true;
+        extensions = [
+          "fzf"
+          "neo-tree"
+        ];
+        disabledFiletypes = {
+          statusline = ["startup" "alpha"];
+        };
+        theme = "catppuccin";
+        sections = {
+          lualine_a = [
+            {
+              name = "mode";
+              icon = " ";
+            }
+          ];
+          lualine_b = [
+            {
+              name = "branch";
+              icon = "";
+            }
+            {
+              name = "diff";
+              extraConfig = {
+                symbols = {
+                  added = " ";
+                  modified = " ";
+                  removed = " ";
+                };
+              };
+            }
+          ];
+          lualine_c = [
+            {
+              name = "diagnostics";
+              extraConfig = {
+                sources = ["nvim_lsp"];
+                symbols = {
+                  error = " ";
+                  warn = " ";
+                  info = " ";
+                  hint = "󰝶 ";
+                };
+              };
+            }
+            {
+              name = "navic";
+            }
+          ];
+          lualine_x = [
+            {
+              name = "filetype";
+              extraConfig = {
+                icon_only = true;
+                separator = "";
+                padding = {
+                  left = 1;
+                  right = 0;
+                };
+              };
+            }
+            {
+              name = "filename";
+              extraConfig = {
+                path = 1;
+              };
+            }
+            {
+              name.__raw = ''
+                function()
+                  local icon = " "
+                  local status = require("copilot.api").status.data
+                  return icon .. (status.message or " ")
+                end,
 
-            cond = function()
-             local ok, clients = pcall(vim.lsp.get_clients, { name = "copilot", bufnr = 0 })
-             return ok and #clients > 0
-            end,
-          '';
-        }
-      ];
-      lualine_y = [
-        {
-          name = "progress";
-        }
-      ];
-      lualine_z = [
-        {
-          name = "location";
-        }
-      ];
+                cond = function()
+                 local ok, clients = pcall(vim.lsp.get_clients, { name = "copilot", bufnr = 0 })
+                 return ok and #clients > 0
+                end,
+              '';
+            }
+          ];
+          lualine_y = [
+            {
+              name = "progress";
+            }
+          ];
+          lualine_z = [
+            {
+              name = "location";
+            }
+          ];
+        };
+      };
     };
   };
 }

--- a/config/plugins/utils/markdown-preview.nix
+++ b/config/plugins/utils/markdown-preview.nix
@@ -4,11 +4,11 @@ _: {
       enable = true;
       settings = {
         browser = "firefox";
-        echo_preview_url = true;
+        echo_preview_url = 1;
         port = "6969";
         preview_options = {
-          disable_filename = true;
-          disable_sync_scroll = true;
+          disable_filename = 1;
+          disable_sync_scroll = 1;
           sync_scroll_type = "middle";
         };
         theme = "dark";


### PR DESCRIPTION
- During build time multiple warnings were shown about the deprecation of certain options. These have been moved to their new places.
- Disable the CMP Ghost Text option because it was driving me nuts.