### PR TITLE
renamed changed lsp names and use web-devicons as a full plugin

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -51,5 +51,6 @@ _: {
     ./plugins/utils/markdown-preview.nix
     ./plugins/utils/obsidian.nix
     ./plugins/utils/toggleterm.nix
+    ./plugins/utils/web-devicons.nix
   ];
 }

--- a/config/plugins/lsp/lsp.nix
+++ b/config/plugins/lsp/lsp.nix
@@ -8,20 +8,20 @@
       inlayHints = true;
       servers = {
         html = {enable = true;};
-        lua-ls = {enable = true;};
-        nil-ls = {enable = true;};
+        lua_ls = {enable = true;};
+        nil_ls = {enable = true;};
+        ts_ls = {enable = true;};
         marksman = {enable = true;};
         pyright = {enable = true;};
         gopls = {enable = true;};
         terraformls = {enable = true;};
-        tsserver = {enable = true;};
         ansiblels = {enable = true;};
         jsonls = {enable = true;};
-        helm-ls = {
+        helm_ls = {
           enable = true;
           extraOptions = {
             settings = {
-              "helm-ls" = {
+              "helm_ls" = {
                 yamlls = {
                   path = "${pkgs.yaml-language-server}/bin/yaml-language-server";
                 };

--- a/config/plugins/utils/extra_plugins.nix
+++ b/config/plugins/utils/extra_plugins.nix
@@ -1,5 +1,4 @@
 {pkgs, ...}: {
   extraPlugins = with pkgs.vimPlugins; [
-    nvim-web-devicons
   ];
 }

--- a/config/plugins/utils/web-devicons.nix
+++ b/config/plugins/utils/web-devicons.nix
@@ -1,0 +1,5 @@
+{
+  plugins.web-devicons = {
+    enable = true;
+  };
+}


### PR DESCRIPTION
fix #48 

- Renamed LSP servers as they were changed upstream.
- Enable web-devicons as a nixvim plugin instead of installing them as a extra package.