### PR TITLE
Git: ignore pre-commit configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.pre-commit-config.yaml

--- a/config/default.nix
+++ b/config/default.nix
@@ -7,7 +7,7 @@ _: {
     ./file_types.nix
 
     # Themes
-    ./plugins/themes/default.nix
+    ./plugins/themes
 
     # Completion
     ./plugins/cmp/cmp.nix


### PR DESCRIPTION
It's generated at runtime and should not be checked in.