### PR TITLE
direnv: create .envrc and load the flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use_flake


### PR DESCRIPTION
Having an `.envrc` and [Direnv](https://direnv.net) installed and allowed to load this directory, pre-commit will be automatically configured and this will prevent any changes that are not formatted from making it into the history (cf #57)

I also recommend merging #58 to avoid committing the pre-commit configuration file that is computed at runtime.