### PR TITLE
config/plugins/lsp: Stop after first formatter

### DIFF
--- a/config/plugins/lsp/conform.nix
+++ b/config/plugins/lsp/conform.nix
@@ -78,48 +78,42 @@
         '';
         notify_on_error = true;
         formatters_by_ft = {
-          html = [
-            [
-              "prettierd"
-              "prettier"
-            ]
-          ];
-          css = [
-            [
-              "prettierd"
-              "prettier"
-            ]
-          ];
-          javascript = [
-            [
-              "prettierd"
-              "prettier"
-            ]
-          ];
-          typescript = [
-            [
-              "prettierd"
-              "prettier"
-            ]
-          ];
+          html = {
+            __unkeyed-1 = "prettierd";
+            __unkeyed-2 = "prettier";
+            stop_after_first = true;
+          };
+          css = {
+            __unkeyed-1 = "prettierd";
+            __unkeyed-2 = "prettier";
+            stop_after_first = true;
+          };
+          javascript = {
+            __unkeyed-1 = "prettierd";
+            __unkeyed-2 = "prettier";
+            stop_after_first = true;
+          };
+          typescript = {
+            __unkeyed-1 = "prettierd";
+            __unkeyed-2 = "prettier";
+            stop_after_first = true;
+          };
           python = [
             "black"
             "isort"
           ];
           lua = [ "stylua" ];
           nix = [ "nixfmt-rfc-style" ];
-          markdown = [
-            [
-              "prettierd"
-              "prettier"
-            ]
-          ];
-          yaml = [
-            [
-              "prettierd"
-              "prettier"
-            ]
-          ];
+          markdown = {
+            __unkeyed-1 = "prettierd";
+            __unkeyed-2 = "prettier";
+            stop_after_first = true;
+          };
+          yaml = {
+            __unkeyed-1 = "prettierd";
+            __unkeyed-2 = "prettier";
+            stop_after_first = true;
+          };
           terraform = [ "terraform_fmt" ];
           bicep = [ "bicep" ];
           bash = [


### PR DESCRIPTION
NeoVim was stuck in an infinite loop saving an HTML file, by stopping after the first successful formatter between `prettierd` and `prettier` the inifinite loop stopped.

(cherry picked from commit https://github.com/kalbasit/nixvim/commit/7e6eb2b64536240b1da5cbbaab220269caffe2d5)