### PR TITLE
Fix disable autoformatting

### DIFF
--- a/config/plugins/lsp/conform.nix
+++ b/config/plugins/lsp/conform.nix
@@ -10,7 +10,7 @@
       ''
         local slow_format_filetypes = {}
 
-        vim.api.nvim_create_user_command("FormatDisable", function(args)
+        vim.api.nvim_create_user_command("ConformFormatDisable", function(args)
            if args.bang then
             -- FormatDisable! will disable formatting just for this buffer
             vim.b.disable_autoformat = true
@@ -21,13 +21,13 @@
           desc = "Disable autoformat-on-save",
           bang = true,
         })
-        vim.api.nvim_create_user_command("FormatEnable", function()
+        vim.api.nvim_create_user_command("ConformFormatEnable", function()
           vim.b.disable_autoformat = false
           vim.g.disable_autoformat = false
         end, {
           desc = "Re-enable autoformat-on-save",
         })
-        vim.api.nvim_create_user_command("FormatToggle", function(args)
+        vim.api.nvim_create_user_command("ConformFormatToggle", function(args)
           if args.bang then
             -- Toggle formatting for current buffer
             vim.b.disable_autoformat = not vim.b.disable_autoformat

--- a/config/plugins/lsp/conform.nix
+++ b/config/plugins/lsp/conform.nix
@@ -39,6 +39,25 @@
           desc = "Toggle autoformat-on-save",
           bang = true,
         })
+
+        vim.api.nvim_create_user_command("AllFormatDisable", function()
+          vim.cmd([[ConformFormatDisable]]) -- conform-nvim
+          vim.cmd([[FormatDisable]]) -- lsp-conform
+        end, {
+          desc = "Disable formatting for all plugins",
+        })
+        vim.api.nvim_create_user_command("AllFormatEnable", function()
+          vim.cmd([[ConformFormatEnable]]) -- conform-nvim
+          vim.cmd([[FormatEnable]]) -- lsp-conform
+        end, {
+          desc = "Re-enable formatting for all plugins",
+        })
+        vim.api.nvim_create_user_command("AllFormatToggle", function()
+          vim.cmd([[ConformFormatToggle]]) -- conform-nvim
+          vim.cmd([[FormatToggle]]) -- lsp-conform
+        end, {
+          desc = "Toggle formatting for all plugins",
+        })
       '';
     plugins.conform-nvim = {
       enable = true;


### PR DESCRIPTION
This PR attempts to fix #91. This is done by renaming the user-defined `conform.nvim` functions `FormatEnable/Disable/Toggle` to `ConformFormatEnable/Disable/Toggle`. Doing so allows to access _other_ functions named `Format...` which are provided in the _global_ name space by `lsp-format.nvim`. The function names where the same.

In a second step, new functions are added, namely `AllFormatEnable/Disable/Toggle` which invoke the corresponding functions for both plugins. Thus, a single command can be used to change the behavior of both plugins.

lsp-format.nvim does not ([yet?](https://github.com/lukas-reineke/lsp-format.nvim/issues/49)) allow disabling on a per-buffer basis. The `All...` functions do not differentiate between all or current buffer neither.

Renaming the functions is a _breaking_ change. Anyone having mapped those function will now invoke the "wrong" ones (previously, the conform.nvim functionality was accessed, now it would be the one from lsp-format.nvim).