### PR TITLE
fix: Fix all deprecation notices from upstream nixvim

### DIFF
--- a/config/plugins/editor/neo-tree.nix
+++ b/config/plugins/editor/neo-tree.nix
@@ -1,53 +1,56 @@
 {
   plugins.neo-tree = {
     enable = true;
-    sources = [
-      "filesystem"
-      "buffers"
-      "git_status"
-      "document_symbols"
-    ];
-    addBlankLineAtTop = false;
 
-    filesystem = {
-      bindToCwd = false;
-      followCurrentFile = {
-        enabled = true;
-      };
-    };
+    settings = {
+      sources = [
+        "filesystem"
+        "buffers"
+        "git_status"
+        "document_symbols"
+      ];
+      add_blank_line_at_top = false;
 
-    defaultComponentConfigs = {
-      indent = {
-        withExpanders = true;
-        expanderCollapsed = "󰅂";
-        expanderExpanded = "󰅀";
-        expanderHighlight = "NeoTreeExpander";
-      };
-
-      gitStatus = {
-        symbols = {
-          added = " ";
-          conflict = "󰩌 ";
-          deleted = "󱂥";
-          ignored = " ";
-          modified = " ";
-          renamed = "󰑕";
-          staged = "󰩍";
-          unstaged = "";
-          untracked = " ";
+      filesystem = {
+        bind_to_cwd = false;
+        follow_current_file = {
+          enabled = true;
         };
       };
+
+      default_component_configs = {
+        indent = {
+          with_expanders = true;
+          expander_collapsed = "󰅂";
+          expander_expanded = "󰅀";
+          expander_highlight = "NeoTreeExpander";
+        };
+
+        git_status = {
+          symbols = {
+            added = " ";
+            conflict = "󰩌 ";
+            deleted = "󱂥";
+            ignored = " ";
+            modified = " ";
+            renamed = "󰑕";
+            staged = "󰩍";
+            unstaged = "";
+            untracked = " ";
+          };
+        };
+      };
+
+      keymaps = [
+        {
+          mode = [ "n" ];
+          key = "<leader>e";
+          action = "<cmd>Neotree toggle<cr>";
+          options = {
+            desc = "Open/Close Neotree";
+          };
+        }
+      ];
     };
   };
-
-  keymaps = [
-    {
-      mode = [ "n" ];
-      key = "<leader>e";
-      action = "<cmd>Neotree toggle<cr>";
-      options = {
-        desc = "Open/Close Neotree";
-      };
-    }
-  ];
 }

--- a/config/plugins/editor/treesitter.nix
+++ b/config/plugins/editor/treesitter.nix
@@ -6,56 +6,58 @@
       indent.enable = true;
       highlight.enable = true;
     };
-    folding = false;
+    folding.enable = false;
     nixvimInjections = true;
     grammarPackages = pkgs.vimPlugins.nvim-treesitter.allGrammars;
   };
 
   plugins.treesitter-textobjects = {
     enable = false;
-    select = {
-      enable = true;
-      lookahead = true;
-      keymaps = {
-        "aa" = "@parameter.outer";
-        "ia" = "@parameter.inner";
-        "af" = "@function.outer";
-        "if" = "@function.inner";
-        "ac" = "@class.outer";
-        "ic" = "@class.inner";
-        "ii" = "@conditional.inner";
-        "ai" = "@conditional.outer";
-        "il" = "@loop.inner";
-        "al" = "@loop.outer";
-        "at" = "@comment.outer";
+    settings = {
+      select = {
+        enable = true;
+        lookahead = true;
+        keymaps = {
+          "aa" = "@parameter.outer";
+          "ia" = "@parameter.inner";
+          "af" = "@function.outer";
+          "if" = "@function.inner";
+          "ac" = "@class.outer";
+          "ic" = "@class.inner";
+          "ii" = "@conditional.inner";
+          "ai" = "@conditional.outer";
+          "il" = "@loop.inner";
+          "al" = "@loop.outer";
+          "at" = "@comment.outer";
+        };
       };
-    };
-    move = {
-      enable = true;
-      gotoNextStart = {
-        "]m" = "@function.outer";
-        "]]" = "@class.outer";
+      move = {
+        enable = true;
+        goto_next_start = {
+          "]m" = "@function.outer";
+          "]]" = "@class.outer";
+        };
+        goto_next_end = {
+          "]M" = "@function.outer";
+          "][" = "@class.outer";
+        };
+        goto_previous_start = {
+          "[m" = "@function.outer";
+          "[[" = "@class.outer";
+        };
+        goto_previous_end = {
+          "[M" = "@function.outer";
+          "[]" = "@class.outer";
+        };
       };
-      gotoNextEnd = {
-        "]M" = "@function.outer";
-        "][" = "@class.outer";
-      };
-      gotoPreviousStart = {
-        "[m" = "@function.outer";
-        "[[" = "@class.outer";
-      };
-      gotoPreviousEnd = {
-        "[M" = "@function.outer";
-        "[]" = "@class.outer";
-      };
-    };
-    swap = {
-      enable = true;
-      swapNext = {
-        "<leader>a" = "@parameters.inner";
-      };
-      swapPrevious = {
-        "<leader>A" = "@parameter.outer";
+      swap = {
+        enable = true;
+        swap_next = {
+          "<leader>a" = "@parameters.inner";
+        };
+        swap_previous = {
+          "<leader>A" = "@parameter.outer";
+        };
       };
     };
   };

--- a/config/plugins/ui/startup.nix
+++ b/config/plugins/ui/startup.nix
@@ -2,12 +2,23 @@
   plugins.startup = {
     enable = true;
 
-    colors = {
-      background = "#ffffff";
-      foldedSection = "#ffffff";
-    };
+    settings = {
+      colors = {
+        background = "#ffffff";
+        foldedSection = "#ffffff";
+      };
+      options = {
+        paddings = [
+          1
+          3
+        ];
+      };
 
-    sections = {
+      parts = [
+        "header"
+        "body"
+      ];
+
       header = {
         type = "text";
         oldfilesDirectory = false;
@@ -72,17 +83,5 @@
         oldfilesAmount = 0;
       };
     };
-
-    options = {
-      paddings = [
-        1
-        3
-      ];
-    };
-
-    parts = [
-      "header"
-      "body"
-    ];
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1759362264,
-        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
@@ -42,34 +42,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1759362264,
-        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -94,41 +76,13 @@
         "type": "github"
       }
     },
-    "ixx": {
-      "inputs": {
-        "flake-utils": [
-          "nixvim",
-          "nuschtosSearch",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixvim",
-          "nuschtosSearch",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1754860581,
-        "narHash": "sha256-EM0IE63OHxXCOpDHXaTyHIOk2cNvMCGPqLt/IdtVxgk=",
-        "owner": "NuschtOS",
-        "repo": "ixx",
-        "rev": "babfe85a876162c4acc9ab6fb4483df88fa1f281",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NuschtOS",
-        "ref": "v0.1.1",
-        "repo": "ixx",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "lastModified": 1766070988,
+        "narHash": "sha256-G/WVghka6c4bAzMhTwT2vjLccg/awmHkdKSd2JrycLc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "rev": "c6245e83d836d0433170a16eb185cefe0572f8b8",
         "type": "github"
       },
       "original": {
@@ -140,11 +94,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -155,11 +109,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1759632233,
-        "narHash": "sha256-krgZxGAIIIKFJS+UB0l8do3sYUDWJc75M72tepmVMzE=",
+        "lastModified": 1766125104,
+        "narHash": "sha256-l/YGrEpLromL4viUo5GmFH3K5M1j0Mb9O+LiaeCPWEM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7f52a7a640bc54c7bb414cca603835bf8dd4b10",
+        "rev": "7d853e518814cca2a657b72eeba67ae20ebf7059",
         "type": "github"
       },
       "original": {
@@ -171,11 +125,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1759070547,
-        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "lastModified": 1764947035,
+        "narHash": "sha256-EYHSjVM4Ox4lvCXUMiKKs2vETUSL5mx+J2FfutM7T9w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "rev": "a672be65651c80d3f592a89b3945466584a22069",
         "type": "github"
       },
       "original": {
@@ -189,43 +143,19 @@
       "inputs": {
         "flake-parts": "flake-parts_2",
         "nixpkgs": "nixpkgs_2",
-        "nuschtosSearch": "nuschtosSearch",
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1759754635,
-        "narHash": "sha256-RzC36w8c+RR/OYZcYN18+QaNdiwfRhzmuhooYiuEamA=",
+        "lastModified": 1766326623,
+        "narHash": "sha256-20uzo3X4mJBF+hfneJMdV/ycTm+4j6bpONaIQ6pq6Vc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4024aa47f0b55058dc05d10eb98cb6387b23b690",
+        "rev": "710ade017755c3b292fd218965f3d282f13a23d7",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "nixvim",
-        "type": "github"
-      }
-    },
-    "nuschtosSearch": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "ixx": "ixx",
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1758662783,
-        "narHash": "sha256-igrxT+/MnmcftPOHEb+XDwAMq3Xg1Xy7kVYQaHhPlAg=",
-        "owner": "NuschtOS",
-        "repo": "search",
-        "rev": "7d4c0fc4ffe3bd64e5630417162e9e04e64b27a4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NuschtOS",
-        "repo": "search",
         "type": "github"
       }
     },
@@ -236,11 +166,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1759523803,
-        "narHash": "sha256-PTod9NG+i3XbbnBKMl/e5uHDBYpwIWivQ3gOWSEuIEM=",
+        "lastModified": 1765911976,
+        "narHash": "sha256-t3T/xm8zstHRLx+pIHxVpQTiySbKqcQbK+r+01XVKc0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "cfc9f7bb163ad8542029d303e599c0f7eee09835",
+        "rev": "b68b780b69702a090c8bb1b973bab13756cc7a27",
         "type": "github"
       },
       "original": {
@@ -258,21 +188,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
This PR update all dependencies and then fixes deprecation notices from upstream.

<details><summary>Copy of the deprecation notices</summary>
<p>

```
❯ nix build .
evaluation warning: Passing a boolean to `plugins.treesitter.folding` is deprecated, use `plugins.treesitter.folding.enable`. Definitions:
                    - In `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix': false
evaluation warning: The option `plugins.treesitter-textobjects.move.enable' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been renamed to `plugins.treesitter-textobjects.settings.move.enable'.
evaluation warning: The option `plugins.treesitter-textobjects.swap.enable' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been renamed to `plugins.treesitter-textobjects.settings.swap.enable'.
evaluation warning: The option `plugins.treesitter-textobjects.select.lookahead' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been renamed to `plugins.treesitter-textobjects.settings.select.lookahead'.
evaluation warning: The option `plugins.treesitter-textobjects.select.enable' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been renamed to `plugins.treesitter-textobjects.settings.select.enable'.
evaluation warning: The option `plugins.treesitter-textobjects.move.gotoPreviousEnd' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been changed to `plugins.treesitter-textobjects.settings.move.goto_previous_end' that has a different type. Please read `plugins.treesitter-textobjects.settings.move.goto_previous_end' documentation and update your configuration accordingly.
evaluation warning: The option `plugins.treesitter-textobjects.move.gotoPreviousStart' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been changed to `plugins.treesitter-textobjects.settings.move.goto_previous_start' that has a different type. Please read `plugins.treesitter-textobjects.settings.move.goto_previous_start' documentation and update your configuration accordingly.
evaluation warning: The option `plugins.treesitter-textobjects.move.gotoNextEnd' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been changed to `plugins.treesitter-textobjects.settings.move.goto_next_end' that has a different type. Please read `plugins.treesitter-textobjects.settings.move.goto_next_end' documentation and update your configuration accordingly.
evaluation warning: The option `plugins.treesitter-textobjects.move.gotoNextStart' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been changed to `plugins.treesitter-textobjects.settings.move.goto_next_start' that has a different type. Please read `plugins.treesitter-textobjects.settings.move.goto_next_start' documentation and update your configuration accordingly.
evaluation warning: The option `plugins.treesitter-textobjects.swap.swapPrevious' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been changed to `plugins.treesitter-textobjects.settings.swap.swap_previous' that has a different type. Please read `plugins.treesitter-textobjects.settings.swap.swap_previous' documentation and update your configuration accordingly.
evaluation warning: The option `plugins.treesitter-textobjects.swap.swapNext' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been changed to `plugins.treesitter-textobjects.settings.swap.swap_next' that has a different type. Please read `plugins.treesitter-textobjects.settings.swap.swap_next' documentation and update your configuration accordingly.
evaluation warning: The option `plugins.treesitter-textobjects.select.keymaps' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/treesitter.nix' has been changed to `plugins.treesitter-textobjects.settings.select.keymaps' that has a different type. Please read `plugins.treesitter-textobjects.settings.select.keymaps' documentation and update your configuration accordingly.
evaluation warning: The option `plugins.startup.parts' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/ui/startup.nix' has been renamed to `plugins.startup.settings.parts'.
evaluation warning: The option `plugins.startup.colors.foldedSection' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/ui/startup.nix' has been renamed to `plugins.startup.settings.colors.folded_section'.
evaluation warning: The option `plugins.startup.colors.background' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/ui/startup.nix' has been renamed to `plugins.startup.settings.colors.background'.
evaluation warning: The option `plugins.startup.options.paddings' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/ui/startup.nix' has been renamed to `plugins.startup.settings.options.paddings'.
evaluation warning: The option `plugins.startup.sections' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/ui/startup.nix' has been changed to `plugins.startup.settings' that has a different type. Please read `plugins.startup.settings' documentation and update your configuration accordingly.
evaluation warning: The option `plugins.neo-tree.filesystem.followCurrentFile.enabled' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.filesystem.follow_current_file.enabled'.
evaluation warning: The option `plugins.neo-tree.filesystem.bindToCwd' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.filesystem.bind_to_cwd'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.gitStatus.symbols.conflict' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.git_status.symbols.conflict'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.gitStatus.symbols.staged' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.git_status.symbols.staged'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.gitStatus.symbols.unstaged' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.git_status.symbols.unstaged'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.gitStatus.symbols.ignored' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.git_status.symbols.ignored'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.gitStatus.symbols.untracked' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.git_status.symbols.untracked'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.gitStatus.symbols.renamed' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.git_status.symbols.renamed'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.gitStatus.symbols.modified' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.git_status.symbols.modified'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.gitStatus.symbols.deleted' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.git_status.symbols.deleted'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.gitStatus.symbols.added' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.git_status.symbols.added'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.indent.expanderHighlight' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.indent.expander_highlight'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.indent.expanderExpanded' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.indent.expander_expanded'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.indent.expanderCollapsed' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.indent.expander_collapsed'.
evaluation warning: The option `plugins.neo-tree.defaultComponentConfigs.indent.withExpanders' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.default_component_configs.indent.with_expanders'.
evaluation warning: The option `plugins.neo-tree.addBlankLineAtTop' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.add_blank_line_at_top'.
evaluation warning: The option `plugins.neo-tree.sources' defined in `/nix/store/rk12h4k9jh7djybxkqvdnxg0a48g10sn-source/config/plugins/editor/neo-tree.nix' has been renamed to `plugins.neo-tree.settings.sources'.
```

</p>
</details> 