### PR TITLE
feat(nixvim): integrate ArchLens relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ home-manager.users.<user>.home.packages = [
 
 ### Utils
 
+- `archlens.nix`: Installs and configures the published ArchLens Neovim plugin.
 - `trouble.nix`: Provides persistent diagnostics, quickfix, location-list, and TODO triage views.
 - `overseer.nix`: Runs bounded, repo-aware validation tasks while keeping persistent sessions in cmux.
 - `telescope.nix`: Configures the Telescope plugin for fuzzy finding and picking.

--- a/config/auto_cmds.nix
+++ b/config/auto_cmds.nix
@@ -23,6 +23,7 @@
       event = [ "FileType" ];
       pattern = [
         "help"
+        "archlens"
         "snacks_dashboard"
         "neo-tree"
         "Trouble"

--- a/config/default.nix
+++ b/config/default.nix
@@ -50,6 +50,7 @@ _: {
     ./plugins/git/gitsigns.nix
 
     # Utils
+    ./plugins/utils/archlens.nix
     ./plugins/utils/trouble.nix
     ./plugins/utils/overseer.nix
     ./plugins/utils/telescope.nix

--- a/config/plugins/lsp/ocaml.nix
+++ b/config/plugins/lsp/ocaml.nix
@@ -10,9 +10,12 @@
     packageFallback = true;
   };
 
-  # OCaml-LSP delegates formatting to ocamlformat. Keep the Nix package as a
-  # fallback so a project-local/opam version remains authoritative.
-  extraPackagesAfter = [ pkgs.ocamlPackages.ocamlformat ];
+  # OCaml-LSP needs Dune to load project documents and delegates formatting to
+  # ocamlformat. Keep both as fallbacks so project-local tools remain authoritative.
+  extraPackagesAfter = [
+    pkgs.dune_3
+    pkgs.ocamlPackages.ocamlformat
+  ];
 
   autoCmd = [
     {

--- a/config/plugins/utils/archlens.nix
+++ b/config/plugins/utils/archlens.nix
@@ -1,0 +1,36 @@
+{
+  archlens,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  extraPlugins = [ archlens ];
+  extraPackagesAfter = [ pkgs.ast-grep ];
+
+  extraConfigLua = lib.mkAfter ''
+    require("archlens").setup({
+      width = 64,
+      max_items = 8,
+      include_external = false,
+      ast_grep = {
+        command = "${lib.getExe pkgs.ast-grep}",
+        timeout_ms = 15000,
+        max_results = 80,
+        min_name_length = 5,
+      },
+    })
+  '';
+
+  keymaps = [
+    {
+      mode = "n";
+      key = "<leader>cm";
+      action = "<cmd>ArchLensHere<cr>";
+      options = {
+        desc = "Map local and project relationships";
+        silent = true;
+      };
+    }
+  ];
+}

--- a/config/plugins/utils/archlens.nix
+++ b/config/plugins/utils/archlens.nix
@@ -6,7 +6,10 @@
 }:
 {
   extraPlugins = [ archlens ];
-  extraPackagesAfter = [ pkgs.ast-grep ];
+  extraPackagesAfter = [
+    pkgs.ast-grep
+    pkgs.ripgrep
+  ];
 
   extraConfigLua = lib.mkAfter ''
     require("archlens").setup({
@@ -18,6 +21,11 @@
         timeout_ms = 15000,
         max_results = 80,
         min_name_length = 5,
+      },
+      imports = {
+        inbound = {
+          command = "${lib.getExe pkgs.ripgrep}",
+        },
       },
     })
   '';

--- a/config/plugins/utils/telescope.nix
+++ b/config/plugins/utils/telescope.nix
@@ -1,6 +1,10 @@
+{ pkgs, ... }:
 {
+  extraPlugins = [ pkgs.vimPlugins.telescope-hierarchy-nvim ];
+
   plugins.telescope = {
     enable = true;
+    enabledExtensions = [ "hierarchy" ];
     extensions = {
       file-browser = {
         enable = true;
@@ -17,6 +21,11 @@
           };
         };
         sorting_strategy = "ascending";
+      };
+      extensions.hierarchy = {
+        initial_multi_expand = false;
+        multi_depth = 5;
+        layout_strategy = "horizontal";
       };
     };
     keymaps = {
@@ -173,6 +182,22 @@
     };
   };
   keymaps = [
+    {
+      mode = "n";
+      key = "<leader>ci";
+      action = "<cmd>Telescope hierarchy incoming_calls<cr>";
+      options = {
+        desc = "Incoming call hierarchy";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>co";
+      action = "<cmd>Telescope hierarchy outgoing_calls<cr>";
+      options = {
+        desc = "Outgoing call hierarchy";
+      };
+    }
     {
       mode = "n";
       key = "<leader>sd";

--- a/config/plugins/utils/trouble.nix
+++ b/config/plugins/utils/trouble.nix
@@ -14,6 +14,18 @@ _: {
   keymaps = [
     {
       mode = "n";
+      key = "<leader>cs";
+      action = "<cmd>Trouble symbols toggle focus=false<cr>";
+      options.desc = "Document symbols";
+    }
+    {
+      mode = "n";
+      key = "<leader>cl";
+      action = "<cmd>Trouble lsp toggle focus=false win.position=right<cr>";
+      options.desc = "LSP locations";
+    }
+    {
+      mode = "n";
       key = "<leader>xx";
       action = "<cmd>Trouble diagnostics toggle<cr>";
       options.desc = "Workspace diagnostics";

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,31 @@
 {
   "nodes": {
+    "archlens": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixvim": [
+          "nixvim"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785703421,
+        "narHash": "sha256-M12DGTZwOyxU/UptyE2T9YFA8InGQtLkmiBG7pwB0SU=",
+        "owner": "dc-tec",
+        "repo": "archlens",
+        "rev": "3eb4ed7514b9bba3175a270b12e3126279ea0fe4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dc-tec",
+        "repo": "archlens",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -216,6 +242,7 @@
     },
     "root": {
       "inputs": {
+        "archlens": "archlens",
         "flake-parts": "flake-parts",
         "md-render": "md-render",
         "mmdr": "mmdr",

--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785713179,
-        "narHash": "sha256-oLeRPm6OW3ooKyttCOKbY6+aCTA6Y9TuoA8N1bCbs5I=",
+        "lastModified": 1785738998,
+        "narHash": "sha256-3uhXT7heuM1plzzRsEZ06KtsPs9Enuuo8+Dbi6uK9WE=",
         "owner": "dc-tec",
         "repo": "archlens",
-        "rev": "af788744d6f6b98809586537d26bb43754117d86",
+        "rev": "2f9476f38479097383080f69daf6a89d037ee36a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785738998,
-        "narHash": "sha256-3uhXT7heuM1plzzRsEZ06KtsPs9Enuuo8+Dbi6uK9WE=",
+        "lastModified": 1785754423,
+        "narHash": "sha256-xYVTi6/3p4bFqoTYKrgUqXBQP8H1ZOq5qv7aqW6AcQ4=",
         "owner": "dc-tec",
         "repo": "archlens",
-        "rev": "2f9476f38479097383080f69daf6a89d037ee36a",
+        "rev": "1c5454f1d559c1e1b9744ea8b31037cc3ce44aa7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785703421,
-        "narHash": "sha256-M12DGTZwOyxU/UptyE2T9YFA8InGQtLkmiBG7pwB0SU=",
+        "lastModified": 1785713179,
+        "narHash": "sha256-oLeRPm6OW3ooKyttCOKbY6+aCTA6Y9TuoA8N1bCbs5I=",
         "owner": "dc-tec",
         "repo": "archlens",
-        "rev": "3eb4ed7514b9bba3175a270b12e3126279ea0fe4",
+        "rev": "af788744d6f6b98809586537d26bb43754117d86",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,14 @@
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
     };
+    archlens = {
+      url = "github:dc-tec/archlens";
+      inputs = {
+        flake-parts.follows = "flake-parts";
+        nixpkgs.follows = "nixpkgs";
+        nixvim.follows = "nixvim";
+      };
+    };
     md-render = {
       url = "github:delphinus/md-render.nvim/v3.4.0";
       flake = false;
@@ -52,6 +60,7 @@
             module = import ./config; # import the module directly
             # You can use `extraSpecialArgs` to pass additional arguments to your module files
             extraSpecialArgs = {
+              archlens = inputs.archlens.packages.${system}.default;
               mdRender = inputs.md-render;
               mmdr = inputs.mmdr.packages.${system}.default;
             };


### PR DESCRIPTION
## Summary

- add code-relationship navigation and OCaml project support
- install and configure ArchLens from the published flake
- advance ArchLens to `2f9476f` with project scope, hierarchy, module, test, and configuration relationships
- add reverse module relationships and contextual grouping for test and configuration uses
- package ripgrep and configure its exact Nix-store path for inbound module indexing

## Validation

- `nix flake check --print-build-logs`
- headless Nixvim smoke test confirms ripgrep is available and the ArchLens import-index and container modules load
