### PR TITLE
chore(archlens): update to 0.1.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785754423,
-        "narHash": "sha256-xYVTi6/3p4bFqoTYKrgUqXBQP8H1ZOq5qv7aqW6AcQ4=",
+        "lastModified": 1785797889,
+        "narHash": "sha256-JeGnzgdlGeZUMPwdOFE/1Pjkg9OzIQWgIpnqpbY7y/A=",
         "owner": "dc-tec",
         "repo": "archlens",
-        "rev": "1c5454f1d559c1e1b9744ea8b31037cc3ce44aa7",
+        "rev": "f3be325fa72db87dc6137ae085208f11ca4a60d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Pin ArchLens to the signed `v0.1.0` release.
- Bring the dogfooded lifecycle UI, type presentation, cursor following, and navigation fixes into Nixvim.

## Validation

- `nix flake check path:. --print-build-logs`
- Configured headless Neovim load with `require("archlens")` and `:ArchLensHere`

The existing `x86_64-darwin` Nixvim input evaluation limitation is unchanged.
