### PR TITLE
feat(nixvim): follow LazyGit worktree switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ home-manager.users.<user>.home.packages = [
 
 - `codediff.nix`: Configures a read-only review workflow for working-tree, branch, and commit-history diffs.
 - `jj.nix`: Configures Jujutsu commands and key mappings.
-- `lazygit.nix`: Configures the LazyGit plugin for Git integration.
+- `lazygit.nix`: Configures LazyGit and opens selected worktrees in new, rooted editor tabs.
 - `gitsigns.nix`: Configures GitSigns diff markers, hunk navigation, inline previews, blame, and word diffs.
 
 ### Utils

--- a/config/plugins/git/lazygit.nix
+++ b/config/plugins/git/lazygit.nix
@@ -1,12 +1,100 @@
-{ pkgs, ... }:
-{
-  extraPlugins = with pkgs.vimPlugins; [
-    lazygit-nvim
-  ];
+_: {
+  plugins.lazygit.enable = true;
 
-  extraConfigLua = ''
-    require("telescope").load_extension("lazygit")
-  '';
+  extraConfigLua = # lua
+    ''
+      require("telescope").load_extension("lazygit")
+
+      local function normalize(path)
+        if not path or path == "" then
+          return nil
+        end
+
+        return vim.uv.fs_realpath(path) or vim.fs.normalize(path)
+      end
+
+      local function git_root(path)
+        local result = vim.system(
+          { "git", "-C", path, "rev-parse", "--show-toplevel" },
+          { text = true }
+        ):wait()
+
+        if result.code ~= 0 then
+          return nil
+        end
+
+        return normalize(vim.trim(result.stdout or ""))
+      end
+
+      local function read_handoff(path)
+        local ok, lines = pcall(vim.fn.readfile, path)
+        vim.fn.delete(path)
+
+        if not ok or not lines[1] then
+          return nil
+        end
+
+        return git_root(vim.trim(lines[1]))
+      end
+
+      local function open_worktree(path)
+        vim.cmd.tabnew()
+        vim.cmd.tcd(vim.fn.fnameescape(path))
+
+        local snacks_ok, snacks = pcall(require, "snacks")
+        if snacks_ok then
+          snacks.dashboard()
+        end
+
+        vim.notify(
+          ("Opened worktree %s"):format(vim.fs.basename(path)),
+          vim.log.levels.INFO,
+          { title = "LazyGit" }
+        )
+      end
+
+      local handoff = vim.fn.tempname()
+      local previous_handoff = vim.env.LAZYGIT_NEW_DIR_FILE
+      local previous_callback = vim.g.lazygit_on_exit_callback
+
+      vim.env.LAZYGIT_NEW_DIR_FILE = handoff
+      vim.g.lazygit_on_exit_callback = function()
+        local source_root = git_root(vim.uv.cwd())
+        local target_root = read_handoff(handoff)
+
+        if type(previous_callback) == "function" then
+          local ok, err = pcall(previous_callback)
+          if not ok then
+            vim.notify(err, vim.log.levels.ERROR, { title = "LazyGit callback" })
+          end
+        end
+
+        if target_root and target_root ~= source_root then
+          open_worktree(target_root)
+        end
+      end
+
+      local lazygit_worktree_group = vim.api.nvim_create_augroup("lazygit_worktree", { clear = true })
+
+      vim.api.nvim_create_autocmd("TermClose", {
+        group = lazygit_worktree_group,
+        callback = function(args)
+          if vim.bo[args.buf].filetype == "lazygit" and vim.v.event.status ~= 0 then
+            vim.fn.delete(handoff)
+          end
+        end,
+      })
+
+      vim.api.nvim_create_autocmd("VimLeavePre", {
+        group = lazygit_worktree_group,
+        once = true,
+        callback = function()
+          vim.fn.delete(handoff)
+          vim.env.LAZYGIT_NEW_DIR_FILE = previous_handoff
+          vim.g.lazygit_on_exit_callback = previous_callback
+        end,
+      })
+    '';
 
   keymaps = [
     {
@@ -14,7 +102,7 @@
       key = "<leader>gg";
       action = "<cmd>LazyGit<CR>";
       options = {
-        desc = "LazyGit (root dir)";
+        desc = "LazyGit (worktree aware)";
       };
     }
   ];


### PR DESCRIPTION
## Summary

- enable LazyGit through Nixvim's native plugin module
- use LazyGit's directory handoff to detect repository and worktree switches
- open a switched worktree in a new tab rooted at that checkout, with the project dashboard
- preserve existing callbacks and clean up the handoff on failed terminal exits and editor shutdown

## Root cause

LazyGit runs as a child process of Neovim. Switching worktrees changes the child's working directory, but a child process cannot change Neovim's working directory, so the editor remained rooted in the original checkout.

## User impact

Selecting another worktree in LazyGit and exiting with `q` now opens that checkout in a new editor tab while preserving the original tab. Exiting with `Q` keeps the original worktree.

## Validation

- `nix flake check path:. --print-build-logs`
- generated Nixvim package build
- headless runtime simulations for changed, unchanged, and failed LazyGit exits
- environment restoration and Snacks dashboard assertions
- manual `nix run path:. -- --cmd 'cd <worktree>'` verification
- `git diff --check`
