### PR TITLE
chore(archlens): track main

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,15 +13,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785797889,
-        "narHash": "sha256-JeGnzgdlGeZUMPwdOFE/1Pjkg9OzIQWgIpnqpbY7y/A=",
+        "lastModified": 1785925126,
+        "narHash": "sha256-eRkBFO2L9NbIT3eKRjPWf2whl5Q4nMOepVnCDoU1OKA=",
         "owner": "dc-tec",
         "repo": "archlens",
-        "rev": "f3be325fa72db87dc6137ae085208f11ca4a60d5",
+        "rev": "abe869e68e614469fe3130e557223590da3fdc68",
         "type": "github"
       },
       "original": {
         "owner": "dc-tec",
+        "ref": "main",
         "repo": "archlens",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       url = "github:cachix/pre-commit-hooks.nix";
     };
     archlens = {
-      url = "github:dc-tec/archlens";
+      url = "github:dc-tec/archlens/main";
       inputs = {
         flake-parts.follows = "flake-parts";
         nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
## Summary
- make the ArchLens input explicitly track `main`
- update the lock from `f3be325` to `abe869e`

## Why
ArchLens is under active development and this Nixvim configuration is used to dogfood it, so tracking `main` keeps the integration current without waiting for release tags.

## Validation
- `nix flake check 'path:.' --print-build-logs`
- headless `require("archlens")` and `:ArchLensHere` smoke test
- `git diff --check`
