### PR TITLE
refactor(archlens): use lazy global configuration

### DIFF
--- a/config/plugins/utils/archlens.nix
+++ b/config/plugins/utils/archlens.nix
@@ -11,24 +11,18 @@
     pkgs.ripgrep
   ];
 
-  extraConfigLua = lib.mkAfter ''
-    require("archlens").setup({
-      width = 64,
-      max_items = 8,
-      include_external = false,
-      ast_grep = {
-        command = "${lib.getExe pkgs.ast-grep}",
-        timeout_ms = 15000,
-        max_results = 80,
-        min_name_length = 5,
-      },
-      imports = {
-        inbound = {
-          command = "${lib.getExe pkgs.ripgrep}",
-        },
-      },
-    })
-  '';
+  globals.archlens = {
+    width = 64;
+    max_items = 8;
+    include_external = false;
+    ast_grep = {
+      command = lib.getExe pkgs.ast-grep;
+      timeout_ms = 15000;
+      max_results = 80;
+      min_name_length = 5;
+    };
+    imports.inbound.command = lib.getExe pkgs.ripgrep;
+  };
 
   keymaps = [
     {

--- a/flake.lock
+++ b/flake.lock
@@ -13,17 +13,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1785925126,
-        "narHash": "sha256-eRkBFO2L9NbIT3eKRjPWf2whl5Q4nMOepVnCDoU1OKA=",
+        "lastModified": 1786043885,
+        "narHash": "sha256-guXDY6d5jQVDJPLYeufuT31DQaJIYA6jVbNNftqCB58=",
         "owner": "dc-tec",
-        "repo": "archlens",
-        "rev": "abe869e68e614469fe3130e557223590da3fdc68",
+        "repo": "archlens.nvim",
+        "rev": "c929e0089ceda35f6cc04573d5a33338e520b2a3",
         "type": "github"
       },
       "original": {
         "owner": "dc-tec",
         "ref": "main",
-        "repo": "archlens",
+        "repo": "archlens.nvim",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       url = "github:cachix/pre-commit-hooks.nix";
     };
     archlens = {
-      url = "github:dc-tec/archlens/main";
+      url = "github:dc-tec/archlens.nvim/main";
       inputs = {
         flake-parts.follows = "flake-parts";
         nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
## Summary

- configure ArchLens through native Nixvim globals so its implementation remains unloaded until an ArchLens command runs
- remove the deprecated `setup()` wrapper while preserving the existing ArchLens options
- switch the flake input to the canonical `dc-tec/archlens.nvim` repository
- lock the merged ArchLens lazy-loading and view-lifecycle stack from `main` at `c929e00`

## Validation

- `nix flake check path:. --print-build-logs`
- generated Neovim startup smoke confirming `vim.g.archlens` is present while `package.loaded.archlens` remains empty
- `:ArchLensHere` smoke confirming lazy lifecycle initialization and source-window focus preservation
